### PR TITLE
Fix for writing data to parcel in BaseRoundCornerProgressBar.SavedState

### DIFF
--- a/library/src/main/java/com/akexorcist/roundcornerprogressbar/common/BaseRoundCornerProgressBar.java
+++ b/library/src/main/java/com/akexorcist/roundcornerprogressbar/common/BaseRoundCornerProgressBar.java
@@ -512,6 +512,10 @@ public abstract class BaseRoundCornerProgressBar extends LinearLayout {
             out.writeInt(this.secondaryProgressColor);
             out.writeInt(this.backgroundColor);
 
+            out.writeInt(this.layoutBackgroundColor);
+            out.writeInt(this.layoutProgress);
+            out.writeInt(this.layoutSecondaryProgress);
+
             out.writeByte((byte) (this.isProgressBarCreated ? 1 : 0));
             out.writeByte((byte) (this.isProgressSetBeforeDraw ? 1 : 0));
             out.writeByte((byte) (this.isMaxProgressSetBeforeDraw ? 1 : 0));


### PR DESCRIPTION
Hi, I've noticed that there were missing values in writeToParcel method (which was causing a crash in my app when restoring state). Generally speaking, when read and write methods doesn't have the same order, it causes **Unmarshalling unknown type code** error. 

You've created great lib, so I decided to help a little bit.
Had a lot of trouble to find this one, though :)

Greetings,
Martin
