### PR TITLE
Seek functionality added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ rcMax
 rcRadius
 rcBackgroundPadding
 rcReverse
+rcSeekAllowed
 rcProgressColor
 rcSecondaryProgressColor
 rcBackgroundColor
@@ -41,6 +42,8 @@ void setSecondaryProgressColor(int colorSecondaryProgress)
 
 boolean isReverse()
 void setReverse(boolean isReverse)
+boolean isUserSeekable()
+void setIsUserSeekable(boolean isUserSeekable)
 
 void setOnProgressChangedListener(OnProgressChangedListener listener)
 float getLayoutWidth()
@@ -163,6 +166,7 @@ compile 'com.akexorcist:RoundCornerProgressBar:2.0.3'
 
 Feature
 ===========================
+* Touch Seeking functionality added. (Enable with XML or programmatically.)
 * Round value configurable (recommend dp) for a corner of progress bar 
 * Color changable for a progress
 * Adjust padding range between progress bar and progress or between image icon and progress
@@ -188,6 +192,7 @@ Include 'com.akexorcist.roundcornerprogressbar' or 'com.akexorcist.iconroundcorn
         app:rcBackgroundRadius="dimension"
         app:rcBackgroundColor="color"
         app:rcProgressColor="color"
+        app:rcSeekAllowed="boolean"
         app:rcProgress="integer"
         app:rcMax="integer" />
 ```
@@ -289,6 +294,7 @@ progress1.setProgressColor(Color.parseColor("#ed3b27"));
 progress1.setBackgroundColor(Color.parseColor("#808080"));
 progress1.setMax(70);
 progress1.setProgress(15);
+progress1.setIsUserSeekable(true);
 
 int progressColor1 = progress1.getProgressColor();
 int backgroundColor1 = progress1.getBackgroundColor();

--- a/library/src/main/java/com/akexorcist/roundcornerprogressbar/common/BaseRoundCornerProgressBar.java
+++ b/library/src/main/java/com/akexorcist/roundcornerprogressbar/common/BaseRoundCornerProgressBar.java
@@ -36,7 +36,6 @@ import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
-import android.widget.SeekBar;
 import android.widget.TextView;
 
 import com.akexorcist.roundcornerprogressbar.R;
@@ -547,8 +546,6 @@ public abstract class BaseRoundCornerProgressBar extends LinearLayout {
      * provides notifications of when the user starts and stops a touch gesture within the SeekBar.
      *
      * @param listener The seek bar notification listener
-     *
-     * @see SeekBar.OnSeekBarChangeListener
      */
     public void setOnSeekBarChangeListener( OnSeekBarChangeListener listener )
     {

--- a/library/src/main/java/com/akexorcist/roundcornerprogressbar/common/BaseRoundCornerProgressBar.java
+++ b/library/src/main/java/com/akexorcist/roundcornerprogressbar/common/BaseRoundCornerProgressBar.java
@@ -316,6 +316,16 @@ public abstract class BaseRoundCornerProgressBar extends LinearLayout {
         return progress;
     }
 
+    public boolean isUserSeekable()
+    {
+        return isUserSeekable;
+    }
+
+    public void setIsUserSeekable( boolean isUserSeekable )
+    {
+        this.isUserSeekable = isUserSeekable;
+    }
+
     public void setProgress( float progress )
     {
         setProgress(progress, false);
@@ -625,9 +635,7 @@ public abstract class BaseRoundCornerProgressBar extends LinearLayout {
                     trackTouchEvent(event);
                     onStopTrackingTouch();
                 }
-                // ProgressBar doesn't know to repaint the thumb drawable
-                // in its inactive state when the touch stops (because the
-                // value has not apparently changed)
+
                 invalidate();
                 break;
             }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -19,6 +19,7 @@ limitations under the License.
 <resources>
 
     <declare-styleable name="RoundCornerProgress">
+        <attr name="rcSeekAllowed" format="boolean" />
         <attr name="rcReverse" format="boolean" />
         <attr name="rcProgress" format="float" />
         <attr name="rcMax" format="float" />


### PR DESCRIPTION
- Added Seeking functionality to the Progress bars with Touch listener.
- Added "rcSeekAllowed" style, in addition to class boolean "isUserSeekable", to allow styling or programming to control whether seeking in allowed. (Class boolean has getter and setter.)
- Added overloaded "setProgress" function that takes a boolean saying whether the set progress action was caused by a user (touch) or by the application (progress increase).
- Made sure touch progress bar seeking does not get interrupted by any scrollview the bar might be inside of.
- Added "OnSeekBarChangeListener" interface inside class to be implemented by any other class that wishes to be notified on seeking events.

<br>
Notes:
- Seeking will only affect the primary progress bar, not the secondary progress bar. (Could be altered later if deemed relevant.)
- Touch functionality could be enabled for some of the Demo ProgressBars. (With Style or Setter.)
