### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven
 
 Gradle
 ```
-compile 'com.akexorcist:RoundCornerProgressBar:2.0.3'
+implementation 'com.akexorcist:RoundCornerProgressBar:2.0.3'
 ```
 
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.